### PR TITLE
Fix for three small bugs:

### DIFF
--- a/py/competitors.py
+++ b/py/competitors.py
@@ -205,7 +205,10 @@ def artd(input_file, B=0):
         if len(P) >= B+1:
             break
 
-        del U[s]
+        try:
+                del U[s]
+        except:
+                pass
         C = C - set([s])
 
     ptime = time.clock() - ptime_start
@@ -280,7 +283,10 @@ def artdAdequacy(input_file, B=0):
             break
 
         Cg = Cg | U[s]
-        del U[s]
+        try:
+                del U[s]
+        except:
+                pass
         C = C - set([s])
 
     ptime = time.clock() - ptime_start

--- a/py/experimentAdequate.py
+++ b/py/experimentAdequate.py
@@ -121,8 +121,8 @@ if __name__ == "__main__":
         sOut = "{}/{}-{}.pickle".format(sPath, "FAST-all", run+1)
         pickle.dump(sel, open(sOut, "wb"))
         tOut = "{}/{}-{}.pickle".format(tPath, "FAST-all", run+1)
-        pickle.dump((pTime, cTime, rTime, fdl, tsr), open(tOut, "wb"))
-        print("FAST-all", pTime, cTime, rTime, fdl, tsr)
+        pickle.dump((pTime, cTime, sTime, fdl, tsr), open(tOut, "wb"))
+        print("FAST-all", pTime, cTime, sTime, fdl, tsr)
 
 
     # WHITEBOX EXPERIMENTS

--- a/py/fastr_adequate.py
+++ b/py/fastr_adequate.py
@@ -90,7 +90,7 @@ def loadSignatures(input_file):
     return sig, time.clock() - start
 
 
-def loadCoverage(wBoxFile):
+def loadCoverageStart1(wBoxFile):
     C = defaultdict(set)
     with open(wBoxFile) as fin:
         for tc, cov in enumerate(fin):
@@ -106,7 +106,7 @@ def fast_pw(input_file, wBoxFile, r, b, bbox=False, k=5, memory=False):
     n = r * b  # number of hash functions
 
     tC0 = time.clock()
-    C = loadCoverage(wBoxFile)
+    C = loadCoverageStart1(wBoxFile)
     tC1 = time.clock()
     maxCov = reduce(lambda x, y: x | y, C.values())
 
@@ -225,7 +225,7 @@ def fast_(input_file, wBoxFile, selsize, r, b, bbox=False, k=5, memory=False):
     n = r * b  # number of hash functions
 
     tC0 = time.clock()
-    C = loadCoverage(wBoxFile)
+    C = loadCoverageStart1(wBoxFile)
     tC1 = time.clock()
     maxCov = reduce(lambda x, y: x | y, C.values())
 


### PR DESCRIPTION
* Instead of the measured sTime, rTime was reported on adequate experiments
* Different functions treat coverage dictionaries differently, some index starting at 1, some index starting at 0. We create different names for the two functions that do this.
* Sometimes, the candidate set in artd and artdAdequacy are empty, and trying to delete elements from the empty set raises an exception. We now ignore that exception.